### PR TITLE
Add Vocova to AI Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,7 @@ A curated list of awesome productivity tools and products to help you stay organ
 *A much more compelete list of **[AI Tools for Productivity](https://productivity.directory/category/ai)***
 
 - **[Motion App](https://usemotion.com)** - [reviews](https://productivity.directory/motion) - [blog post](https://blog.productivity.directory/motion-app-review-a-deep-dive-into-the-ai-powered-productivity-app-78081e8107f7) - Automation for connecting apps and services.
+- **[Vocova](https://vocova.app)** - AI transcription with bilingual side-by-side export, ideal for translating meetings and interviews across 100+ languages.
 
 
 ---


### PR DESCRIPTION
Adds [Vocova](https://vocova.app) to the AI Tools section.

Vocova provides AI transcription with bilingual side-by-side export — paste any audio/video URL and get transcripts in 100+ languages with speaker labels.