### PR TITLE
Add BulkPublish

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,7 @@ A curated list of awesome productivity tools and products to help you stay organ
 1. **[IFTTT](https://ifttt.com)** - Automation for connecting apps and services.
 2. **[Zapier](https://zapier.com)** - Automation for busy people.
 3. **[Trello Power-Ups](https://trello.com/power-ups)** - Enhancements for Trello.
+4. **[BulkPublish](https://www.bulkpublish.com)** - Social media scheduling for 11 platforms — compose once, publish everywhere. Free tier available.
 
 ## AI Tools
 


### PR DESCRIPTION
Adds [BulkPublish](https://www.bulkpublish.com) to the Miscellaneous section.

BulkPublish is a social media scheduling tool that supports 11 platforms — compose once, publish everywhere. It offers a free tier ($0 forever), a REST API, Python & Node.js SDKs, and integrations with Zapier, n8n, Make, and IFTTT.