### PR TITLE
added Shiplog to project management (Shiplog.page)

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ A curated list of awesome productivity tools and products to help you stay organ
 1. **[Jira](https://www.atlassian.com/software/jira)** - [review](https://productivity.directory/jira) - Issue and project tracking for software teams.
 2. **[Monday.com](https://monday.com)** - [review](https://productivity.directory/mondaydotcom) - Work operating system for teams.
 3. **[Basecamp](https://basecamp.com)** - [review](https://productivity.directory/basecamp) - Real-time communication tool for teams.
+4.  **[Shiplog](https://shiplog.page)** - Polished changelogs hosted on a public page (yourapp.shiplog.page). Push via CLI or Dashboard.
 
 ## Calendar and Scheduling
 


### PR DESCRIPTION
I proposed to add a tool called Shiplog (https://shiplog.page) that allows creators and developers to organise and host their product's updates on their own polished changelog public page (yourapp.shiplog.page). They can add entries via UI Dashboard, AI (by entering rough notes) or CLI directly from the project's terminal. The entire setup takes less than 60 seconds. Free 7-day trial, then 4.99$/mo. Example page: https://calcifyai.shiplog.page