### PR TITLE
Add AI Dictation to AI Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ A curated list of awesome productivity tools and products to help you stay organ
 *A much more compelete list of **[AI Tools for Productivity](https://productivity.directory/category/ai)***
 
 - **[Motion App](https://usemotion.com)** - [reviews](https://productivity.directory/motion) - [blog post](https://blog.productivity.directory/motion-app-review-a-deep-dive-into-the-ai-powered-productivity-app-78081e8107f7) - Automation for connecting apps and services.
-- **[AI Dictation](https://aidictation.com/)** - macOS speech-to-text app that auto-switches between offline and online engines, with AI cleanup that removes filler words, fixes grammar, and formats text per app. Free tier (2,000 words/month, no account required).
+- **[AI Dictation](https://aidictation.com/)** - Open-source voice-to-text app for macOS, Windows, iPhone, iPad, and Android, with offline recognition on supported devices and optional cloud transcription and cleanup.
 
 
 ---

--- a/README.md
+++ b/README.md
@@ -110,6 +110,7 @@ A curated list of awesome productivity tools and products to help you stay organ
 *A much more compelete list of **[AI Tools for Productivity](https://productivity.directory/category/ai)***
 
 - **[Motion App](https://usemotion.com)** - [reviews](https://productivity.directory/motion) - [blog post](https://blog.productivity.directory/motion-app-review-a-deep-dive-into-the-ai-powered-productivity-app-78081e8107f7) - Automation for connecting apps and services.
+- **[AI Dictation](https://aidictation.com/)** - macOS speech-to-text app that auto-switches between offline and online engines, with AI cleanup that removes filler words, fixes grammar, and formats text per app. Free tier (2,000 words/month, no account required).
 
 
 ---


### PR DESCRIPTION
## What changed

Adds [AI Dictation](https://aidictation.com/) to AI Tools with current, claim-safe product coverage: an open-source voice-to-text app for macOS, Windows, iPhone, iPad, and Android, with offline recognition on supported devices and optional cloud transcription and cleanup.

The refreshed entry removes platform-limited wording and price details that can become stale.

## Validation

- Checked the current website, repository README, native client source, and root MIT license.
- Confirmed there is only one AI Dictation entry in the list.
- Ran `git diff --check` and verified the website link.

## Disclosure

I am affiliated with AI Dictation and am submitting it openly rather than presenting this as an independent recommendation. This refresh and pull-request description were prepared with AI assistance, then checked against the current project and this repository's contribution instructions.
