### PR TITLE
Add Remove Audio — free browser tool to mute videos instantly

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,7 @@ A curated list of awesome productivity tools and products to help you stay organ
 3. **[Box](https://www.box.com)** - Cloud content management and file sharing service for businesses.
 
 ## Miscellaneous
+- [Remove Audio](https://remove-audio.com) — Free browser-based tool to remove audio from video files instantly. No uploads, no software to install, batch up to 20 clips.
 
 1. **[IFTTT](https://ifttt.com)** - Automation for connecting apps and services.
 2. **[Zapier](https://zapier.com)** - Automation for busy people.


### PR DESCRIPTION
[Remove Audio](https://remove-audio.com) is a free productivity tool for quickly removing audio from video files — no desktop software, no uploads, no account needed.

Useful for creators who need silent autoplay clips for social feeds, clean B-roll, or muted versions of recordings. Processes files locally in the browser (WebAssembly + FFmpeg.wasm), so it's fast and privacy-respecting.

- Free, no watermarks, no paywall
- Batch up to 20 files at once
- Works on mobile (iPhone + Android)