### PR TITLE
Add TimezonePair to Calendar and Scheduling

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ A curated list of awesome productivity tools and products to help you stay organ
 1. **[Google Calendar](https://calendar.google.com)** - [review](https://productivity.directory/google-Calendar) - Time management and scheduling tool.
 2. **[Calendly](https://calendly.com)** - [review](https://productivity.directory/calendly) - Automated scheduling software.
 3. **[Fantastical](https://flexibits.com/fantastical)** - [review](https://productivity.directory/fantastical) - Calendar app with natural language event creation.
+4. **[TimezonePair](https://www.timezonepair.com)** — Live clocks and business-hours overlap for any two cities. One-click .ics calendar invite, shareable URL, DST-aware, no sign-up.
 
 ## Mind Mapping
 


### PR DESCRIPTION
**What:** Add [TimezonePair](https://www.timezonepair.com) to the Calendar and Scheduling section.
**Why:** TimezonePair is a free tool for distributed teams, remote workers, and anyone scheduling meetings across time zones. Pick any two of 300 cities to see live clocks, a 24-hour business-hours overlap band, and a one-click .ics calendar invite that imports into Google Calendar, Outlook, and Apple Calendar. DST-aware, no sign-up, no tracking.
**Note:** Does not have a productivity.directory review link yet — happy to add one if required.