### PR TITLE
Add HabitIt to Habit Tracking section (created habit tracking section)

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,10 @@ A curated list of awesome productivity tools and products to help you stay organ
 - [ClickUp](https://productivity.directory/clickup)
 - [Microsoft Project](https://productivity.directory/microsoft-project)
 
+## Habit Tracking
+
+1. **[HabitIt](https://habitit.app)** - Habit tracker with auto-tapering schedules. Habit chains, automatic pattern detection, money-saved counter, AI insights, Health sync (iOS, Android, Apple Watch, Wear OS).
+
 ## Time Tracking
 
 1. **[Toggl](https://toggl.com)** - [review](https://productivity.directory/toggl) - [tutorial](https://blog.productivity.directory/how-to-use-toggl-track-a-beginners-guide-2bd299986bcb) - Easy time tracking for any project.


### PR DESCRIPTION
Added HabitIt to the Habits section.

HabitIt is a habit tracker with auto-tapering daily schedules for starting, quitting, or gradually reducing habits. It does structured daily logging, bidirectional Apple Health and Health Connect sync, and pattern detection over the user's behavior data, which fits the quantified-self theme of the list.

The wedge feature compared to other entries in this section (Habitica, Streaks, Productive, etc.) is the auto-tapering engine: the user sets a start value, target, and timeline, and the app generates the daily plan and recalibrates forward when the user misses a day, rather than breaking the streak.

iOS, Android, Apple Watch, Wear OS. Freemium with a Lifetime Pro IAP.

Happy to adjust the entry's length or wording if you'd prefer a different format.