### PR TITLE
Add Habit Trackers section + LockIN

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,10 @@ A curated list of awesome productivity tools and products to help you stay organ
 2. **[Google Drive](https://drive.google.com)** - File storage and synchronization service.
 3. **[Box](https://www.box.com)** - Cloud content management and file sharing service for businesses.
 
+## Habit Trackers
+
+1. **[LockIN](https://staylockedin.tech)** - Free habit tracker with daily streaks, community accountability feed, XP gamification, and cross-device sync (Web, Android, macOS, Windows).
+
 ## Miscellaneous
 
 1. **[IFTTT](https://ifttt.com)** - Automation for connecting apps and services.


### PR DESCRIPTION
Adds a missing Habit Trackers section with [LockIN](https://staylockedin.tech) — a free habit tracker with daily streaks, social community feed, XP gamification, and cross-device sync (Web, Android, macOS, Windows).