### PR TITLE
Add CapyBro to AI Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,7 @@ A curated list of awesome productivity tools and products to help you stay organ
 
 *A much more compelete list of **[AI Tools for Productivity](https://productivity.directory/category/ai)***
 
+- **[CapyBro](https://capybro.app)** - Open-source Windows tray utility that rewrites, fixes grammar, or translates any selected text in any app via a global hotkey. Supports OpenRouter cloud or fully-local Ollama.
 - **[Motion App](https://usemotion.com)** - [reviews](https://productivity.directory/motion) - [blog post](https://blog.productivity.directory/motion-app-review-a-deep-dive-into-the-ai-powered-productivity-app-78081e8107f7) - Automation for connecting apps and services.
 
 


### PR DESCRIPTION
Adding CapyBro - an open-source (MIT) Windows tray utility that brings AI text editing directly into any application via a global hotkey.

Workflow: select text in any program (Word, browser, email, IDE), press Ctrl+Shift+E, AI rewrites it in place. A prompt-picker menu (Ctrl+Shift+Q) gives quick access to grammar fix, translation, tone change, and any custom prompts the user creates.

Productivity angle: removes the constant context-switching to ChatGPT in a browser tab. AI lives at the OS level, available wherever the user is already working.

- Website: https://capybro.app
- Source: https://github.com/phantasmat2018/capy-bro
- License: MIT
- Pricing: Free (bring your own OpenRouter key or run Ollama locally) + optional $19 one-time Pro

Inserted in AI Tools section alphabetically, before Motion App.