### PR TITLE
Add Leaf to Focus Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,7 @@ A curated list of awesome productivity tools and products to help you stay organ
 1. **[Forest](https://www.forestapp.cc)** - App that helps stay focused by planting virtual trees.
 2. **[Freedom](https://freedom.to)** - Block distracting websites and apps.
 3. **[Focus@Will](https://www.focusatwill.com)** - Music service based on human neuroscience to improve focus.
+4. **[Leaf](https://readwithleaf.app)** - Reading habit tracker with daily streaks and a milestone tree to keep you reading consistently. Free to use, with an optional Pro plan.
 
 ## File Organization
 


### PR DESCRIPTION
Adding Leaf, a free reading habit tracker, to the Focus Tools section. It's similar in spirit to Forest (already listed): it gamifies a daily habit, in this case reading, with streaks and a milestone tree to keep you consistent. Multi-platform (iOS/Android), free to use with an optional Pro plan.

Disclosure: I maintain Leaf. Happy to adjust the wording or move it to a different section if you'd prefer.