### PR TITLE
Add CallURL to AI productivity tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,7 @@ A curated list of awesome productivity tools and products to help you stay organ
 *A much more compelete list of **[AI Tools for Productivity](https://productivity.directory/category/ai)***
 
 - **[Motion App](https://usemotion.com)** - [reviews](https://productivity.directory/motion) - [blog post](https://blog.productivity.directory/motion-app-review-a-deep-dive-into-the-ai-powered-productivity-app-78081e8107f7) - Automation for connecting apps and services.
+- **[CallURL](https://callurl.com)** - Shareable Call Apps that are given a job and handle calls.
 
 
 ---


### PR DESCRIPTION
Adds CallURL to the AI Tools section. CallURL lets people create shareable Call Apps that are given a job and can handle calls.