### PR TITLE
Add Oats to productivity tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ A curated list of awesome productivity tools and products to help you stay organ
 2. **[Notion](https://www.notion.so)** - [review](https://productivity.directory/notion) - All-in-one workspace for notes, tasks, wikis, and databases.
 3. **[OneNote](https://www.onenote.com)** - Microsoft's digital note-taking app.
 4. **[Joplin](https://joplinapp.org)** - [review](https://productivity.directory/joplin) - Note-taking, to-do app.
+5. **[OATS](https://github.com/ariso-ai/oats)** - Open-source macOS meeting-notes app with live transcription, speaker labels, AI summaries, and offline on-device mode.
 
 ## Collaboration
 


### PR DESCRIPTION
Adds Oats under Note Taking as an open-source macOS meeting-notes app with live transcription, speaker labels, AI summaries, and offline on-device mode.
