### PR TITLE
Add usage to AI Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,7 @@ A curated list of awesome productivity tools and products to help you stay organ
 *A much more compelete list of **[AI Tools for Productivity](https://productivity.directory/category/ai)***
 
 - **[Motion App](https://usemotion.com)** - [reviews](https://productivity.directory/motion) - [blog post](https://blog.productivity.directory/motion-app-review-a-deep-dive-into-the-ai-powered-productivity-app-78081e8107f7) - Automation for connecting apps and services.
+- **[usage](https://github.com/aqua5230/usage)** - macOS menu bar app that tracks Claude Code, Codex, and Antigravity quota, tokens, and cost so you stay productive without running out of AI budget mid-task.
 
 
 ---


### PR DESCRIPTION
**[usage](https://github.com/aqua5230/usage)** - macOS menu bar app that keeps Claude Code, Codex, and Antigravity quota, tokens, and cost visible while you work. Reads local session logs only. Free, open source (AGPL-3.0).