### PR TITLE
Add Standup Timer — free daily meeting timer

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ A curated list of awesome productivity tools and products to help you stay organ
 6. **[Toggl Track](https://toggl.com/track)** - [review](https://productivity.directory/toggl-track) - Time-tracking app with Pomodoro features for professionals.
 7. **[Focus Booster](https://www.focusboosterapp.com)** - [review](https://productivity.directory/focus-booster) - Pomodoro app with detailed productivity reporting.
 8. **[TomatoTimer](https://tomato-timer.com)** - [review](https://productivity.directory/tomato-timer) - Free and simple Pomodoro timer for web users.
+9. **[Standup Timer](https://ordinarymantrying.com/tools/standup-timer.html)** - Free browser-based standup timer designed for daily team meetings. Tracks speaking time per person, sounds alerts, and keeps standups under 15 minutes.
 
 ## Note Taking
 


### PR DESCRIPTION
## What

Adding [Standup Timer](https://ordinarymantrying.com/tools/standup-timer.html) to the Pomodoro Timer Apps section.

## Why it fits

Most Pomodoro timers are for solo focus work. This one is built specifically for daily standup meetings — tracks time per person, sounds alerts when someone runs long, and helps teams keep standups under 15 minutes.

Works entirely in the browser, free, no signup, no install. Great for remote teams that want a lightweight alternative to heavy meeting software.

## Details
- Pricing: Free
- Platform: Web (any browser)
- No account required