### PR TITLE
Add Tabox

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,7 @@ A curated list of awesome productivity tools and products to help you stay organ
 1. **[IFTTT](https://ifttt.com)** - Automation for connecting apps and services.
 2. **[Zapier](https://zapier.com)** - Automation for busy people.
 3. **[Trello Power-Ups](https://trello.com/power-ups)** - Enhancements for Trello.
+4. **[Tabox](https://chromewebstore.google.com/detail/tabox-save-and-share-tab/bdbliblipiempfdkkkjohnecmeknnpoa)** - Browser extension that saves tabs and tab groups into collections and restores entire sessions in one click.
 
 ## AI Tools
 


### PR DESCRIPTION
Adds [Tabox](https://chromewebstore.google.com/detail/tabox-save-and-share-tab/bdbliblipiempfdkkkjohnecmeknnpoa) — a free, open-source browser extension (https://github.com/gilgold/tabox) that saves all open tabs and tab groups into named collections and reopens the exact session (windows, groups, colors, order) in one click. Google Drive sync across devices, share-via-link, AI-powered tab organization. 4.4★ on the Chrome Web Store; works on Chrome, Edge and Firefox.

Disclosure: I'm the developer of Tabox.

🤖 Generated with [Claude Code](https://claude.com/claude-code)