### PR TITLE
Add Atomic Productivity to AI Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,7 @@ A curated list of awesome productivity tools and products to help you stay organ
 *A much more compelete list of **[AI Tools for Productivity](https://productivity.directory/category/ai)***
 
 - **[Motion App](https://usemotion.com)** - [reviews](https://productivity.directory/motion) - [blog post](https://blog.productivity.directory/motion-app-review-a-deep-dive-into-the-ai-powered-productivity-app-78081e8107f7) - Automation for connecting apps and services.
+- **[Atomic Productivity](https://atomicproductivity.com)** - Free ADHD-friendly productivity suite with AI task breakdown, Pomodoro timer, sound mixer, habit tracker, and self-assessment — no signup required.
 
 
 ---


### PR DESCRIPTION
Add Atomic Productivity (https://atomicproductivity.com) to the AI Tools section.\n\nFree ADHD-friendly productivity suite with AI-powered task breakdown, Pomodoro timer, focus sound mixer, habit tracker, and ADHD self-assessment. No signup required, all tools free to use.