### PR TITLE
Add Persona to Note Taking

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ A curated list of awesome productivity tools and products to help you stay organ
 2. **[Notion](https://www.notion.so)** - [review](https://productivity.directory/notion) - All-in-one workspace for notes, tasks, wikis, and databases.
 3. **[OneNote](https://www.onenote.com)** - Microsoft's digital note-taking app.
 4. **[Joplin](https://joplinapp.org)** - [review](https://productivity.directory/joplin) - Note-taking, to-do app.
+5. **[Persona](https://github.com/jayamitkatariya/personacli)** - Local-first workspace: Markdown notes, tasks, and an AI chat grounded in your own files.
 
 ## Collaboration
 


### PR DESCRIPTION
Adds [Persona](https://github.com/jayamitkatariya/personacli) to the **Note Taking** section.

Persona is a local-first personal workspace: notes and tasks as plain Markdown on your machine (no cloud, no accounts), with an AI chat grounded in your own files. MIT.